### PR TITLE
Fix list of endpoints (cont.)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -198,6 +198,7 @@ List of supported endpoints
 ---------------------------
 
 .. code:: py
+
     # Flight Inspiration Search
     amadeus.shopping.flight_destinations.get(origin='MAD')
 


### PR DESCRIPTION
Added  back the list of endpoints on the README: just needed 2 white spaces

@anthonyroux 