### PR TITLE
SDK - Trip Purpose Prediction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -256,6 +256,9 @@ List of supported endpoints
     # What are the popular places in Barcelona? (based on a square)
     amadeus.reference_data.locations.points_of_interest.by_square.get(north=41.397158, west=2.160873, south=41.394582, east=2.177181)
 
+    # Trip Purpose Prediction
+    amadeus.travel.predictions.trip_purpose.get(originLocationCode='ATH', destinationLocationCode='MAD', departureDate='2020-08-01', returnDate='2020-08-12', searchDate='2020-06-11')
+
 
 Development & Contributing
 --------------------------

--- a/amadeus/namespaces/_travel.py
+++ b/amadeus/namespaces/_travel.py
@@ -1,8 +1,10 @@
 from amadeus.client.decorator import Decorator
 from amadeus.travel._analytics import Analytics
+from amadeus.travel._predictions import Predictions
 
 
 class Travel(Decorator, object):
     def __init__(self, client):
         Decorator.__init__(self, client)
         self.analytics = Analytics(client)
+        self.predictions = Predictions(client)

--- a/amadeus/travel/__init__.py
+++ b/amadeus/travel/__init__.py
@@ -1,5 +1,4 @@
 from ._analytics import Analytics
-from .predictions._trip_purpose import TripPurpose
-
+from ._predictions import TripPurpose
 
 __all__ = ['Analytics', 'TripPurpose']

--- a/amadeus/travel/__init__.py
+++ b/amadeus/travel/__init__.py
@@ -1,4 +1,5 @@
 from ._analytics import Analytics
+from .predictions._trip_purpose import TripPurpose
 
 
-__all__ = ['Analytics']
+__all__ = ['Analytics', 'TripPurpose']

--- a/amadeus/travel/_predictions.py
+++ b/amadeus/travel/_predictions.py
@@ -1,0 +1,8 @@
+from amadeus.client.decorator import Decorator
+from amadeus.travel.predictions._trip_purpose import TripPurpose
+
+
+class Predictions(Decorator, object):
+    def __init__(self, client):
+        Decorator.__init__(self, client)
+        self.trip_purpose = TripPurpose(client)

--- a/amadeus/travel/_predictions.py
+++ b/amadeus/travel/_predictions.py
@@ -1,5 +1,5 @@
 from amadeus.client.decorator import Decorator
-from amadeus.travel.predictions._trip_purpose import TripPurpose
+from .predictions import TripPurpose
 
 
 class Predictions(Decorator, object):

--- a/amadeus/travel/predictions/__init__.py
+++ b/amadeus/travel/predictions/__init__.py
@@ -1,0 +1,4 @@
+from ._trip_purpose import TripPurpose
+
+
+__all__ = ['TripPurpose']

--- a/amadeus/travel/predictions/_trip_purpose.py
+++ b/amadeus/travel/predictions/_trip_purpose.py
@@ -4,31 +4,32 @@ from amadeus.client.decorator import Decorator
 class TripPurpose(Decorator, object):
     def get(self, **params):
         '''
-        Get forecast traveler purpose, Business or Leisure,
-        together with the probability in the context of search & shopping
+        Predicts traveler purpose, Business or Leisure,
+        with the probability in the context of search & shopping
 
         .. code-block:: python
 
-            amadeus.trip.trip_purpose_prediction.get(originLocationCode='XKPARC12',
-            destinationLocationCode='XKPARC12',
-            departureDate='XKPARC12', returnDate='XKPARC12',
-            searchDate='XKPARC12')
+            amadeus.travel.predictions.trip_purpose.get(
+                            originLocationCode='NYC',
+                            destinationLocationCode='MAD',
+                            departureDate='2020-08-01',
+                            returnDate='2020-08-12',
+                            searchDate='2020-06-11')
 
-        :param originLocationCode: Amadeus Property Code (8 chars), for
-            example ``XKPARC12``.
+        :param originLocationCode: the City/Airport IATA code from which
+            the flight will depart. ``"NYC"``, for example for New York
 
-        :param destinationLocationCode: the City/Airport IATA code from which
-        the flight will
-            depart. ``"MAD"``, for example for Madrid.
+        :param destinationLocationCode: the City/Airport IATA code to which
+            the flight is going. ``"MAD"``, for example for Madrid
 
-        :param departureDate: the City/Airport IATA code to which the flight is
-            going. ``"BOS"``, for example for Boston.
+        :param departureDate: the date on which to fly out, in `YYYY-MM-DD` format
 
-        :param returnDate: the date on which to fly out, in `YYYY-MM-DD`
-            format
+        :param returnDate: the date on which the flight returns to the origin,
+            in `YYYY-MM-DD` format
 
-        :param searchDate: the date on which to fly out, in `YYYY-MM-DD`
-            format
+        :param searchDate: the date on which the traveler performs the search,
+            in `YYYY-MM-DD` format.
+            If it is not specified the current date will be used
 
         :rtype: amadeus.Response
         :raises amadeus.ResponseError: if the request could not be completed

--- a/amadeus/travel/predictions/_trip_purpose.py
+++ b/amadeus/travel/predictions/_trip_purpose.py
@@ -1,0 +1,36 @@
+from amadeus.client.decorator import Decorator
+
+
+class TripPurpose(Decorator, object):
+    def get(self, **params):
+        '''
+        Get forecast traveler purpose, Business or Leisure,
+        together with the probability in the context of search & shopping
+
+        .. code-block:: python
+
+            amadeus.trip.trip_purpose_prediction.get(originLocationCode='XKPARC12',
+            destinationLocationCode='XKPARC12',
+            departureDate='XKPARC12', returnDate='XKPARC12',
+            searchDate='XKPARC12')
+
+        :param originLocationCode: Amadeus Property Code (8 chars), for
+            example ``XKPARC12``.
+
+        :param destinationLocationCode: the City/Airport IATA code from which
+        the flight will
+            depart. ``"MAD"``, for example for Madrid.
+
+        :param departureDate: the City/Airport IATA code to which the flight is
+            going. ``"BOS"``, for example for Boston.
+
+        :param returnDate: the date on which to fly out, in `YYYY-MM-DD`
+            format
+
+        :param searchDate: the date on which to fly out, in `YYYY-MM-DD`
+            format
+
+        :rtype: amadeus.Response
+        :raises amadeus.ResponseError: if the request could not be completed
+        '''
+        return self.client.get('/v1/travel/predictions/trip-purpose', **params)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,6 +68,12 @@ Travel/Analytics
 .. autoclass:: amadeus.travel.analytics.FareSearches
   :members: get
 
+Travel/Predictions
+================
+
+.. autoclass:: amadeus.travel.predictions.TripPurpose
+  :members: get
+
 ReferenceData/Locations
 =======================
 

--- a/specs/namespaces/namespaces_spec.py
+++ b/specs/namespaces/namespaces_spec.py
@@ -35,6 +35,9 @@ with description('Namespaces') as self:
             be_none)
         expect(client.travel.analytics.air_traffic.busiest_period).not_to(be_none)
 
+        expect(client.travel.predictions).not_to(be_none)
+        expect(client.travel.predictions.trip_purpose).not_to(be_none)
+
         expect(client.shopping).not_to(be_none)
         expect(client.shopping.flight_dates).not_to(be_none)
         expect(client.shopping.flight_destinations).not_to(be_none)
@@ -67,6 +70,8 @@ with description('Namespaces') as self:
         expect(
             client.travel.analytics.air_traffic.busiest_period.get).not_to(
             be_none)
+
+        expect(client.travel.predictions.trip_purpose.get).not_to(be_none)
 
         expect(client.shopping.flight_dates.get).not_to(be_none)
         expect(client.shopping.flight_destinations.get).not_to(be_none)
@@ -155,6 +160,12 @@ with description('Namespaces') as self:
                 have_been_called_with(
                     '/v1/travel/analytics/air-traffic/searched/by-destination',
                     a='b'))
+
+        with it('.travel.predictions.trip_purpose.get'):
+            self.client.travel.predictions.trip_purpose.get(a='b')
+            expect(self.client.get).to(have_been_called_with(
+                '/v1/travel/predictions/trip-purpose', a='b'
+            ))
 
         with it('.shopping.flight_dates.get'):
             self.client.shopping.flight_dates.get(a='b')


### PR DESCRIPTION
Fixes https://github.com/amadeus4dev/amadeus-python/issues/41

## Changes for this pull request

- Adds Python support for [Trip Purpose Prediction API](https://developers.amadeus.com/self-service/category/trip/api-doc/trip-purpose-prediction/api-reference).

- The class `TripPurpose()` in the file `amadeus/travel/predictions/_trip_purpose.py` contains the method for calling the API programmatically.

- The API can now be called from any application uses the SDK as:
`amadeus.travel.predictions.trip_purpose.get(originLocationCode='XXX', destinationLocationCode='XXX', departureDate='YYYY-MM-DD', returnDate='YYYY-MM-DD', searchDate='YYYY-MM-DD') `.

- Updates docs at `README.str` and `_trip_purpose.py`.

- Updates tests at `namespaces_spec.py`.
