### PR TITLE
Add support for Flight Delay Prediction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -270,6 +270,8 @@ List of supported endpoints
     # Trip Purpose Prediction
     amadeus.travel.predictions.trip_purpose.get(originLocationCode='ATH', destinationLocationCode='MAD', departureDate='2020-08-01', returnDate='2020-08-12', searchDate='2020-06-11')
 
+    # Flight Delay Prediction
+    amadeus.travel.predictions.flight_delay.get(originLocationCode='BRU', destinationLocationCode='FRA', departureDate='2020-01-14', departureTime='11:05:00', arrivalDate='2020-01-14', arrivalTime='12:10:00', aircraftCode='32A', carrierCode='LH', flightNumber='1009', duration='PT1H05M')
 
 Development & Contributing
 --------------------------

--- a/amadeus/travel/__init__.py
+++ b/amadeus/travel/__init__.py
@@ -1,4 +1,4 @@
 from ._analytics import Analytics
-from ._predictions import TripPurpose
+from ._predictions import TripPurpose, FlightDelay
 
-__all__ = ['Analytics', 'TripPurpose']
+__all__ = ['Analytics', 'TripPurpose', 'FlightDelay']

--- a/amadeus/travel/_predictions.py
+++ b/amadeus/travel/_predictions.py
@@ -1,8 +1,9 @@
 from amadeus.client.decorator import Decorator
-from .predictions import TripPurpose
+from .predictions import TripPurpose, FlightDelay
 
 
 class Predictions(Decorator, object):
     def __init__(self, client):
         Decorator.__init__(self, client)
         self.trip_purpose = TripPurpose(client)
+        self.flight_delay = FlightDelay(client)

--- a/amadeus/travel/predictions/__init__.py
+++ b/amadeus/travel/predictions/__init__.py
@@ -1,4 +1,5 @@
 from ._trip_purpose import TripPurpose
+from ._flight_delay import FlightDelay
 
 
-__all__ = ['TripPurpose']
+__all__ = ['TripPurpose', 'FlightDelay']

--- a/amadeus/travel/predictions/_flight_delay.py
+++ b/amadeus/travel/predictions/_flight_delay.py
@@ -1,0 +1,52 @@
+from amadeus.client.decorator import Decorator
+
+
+class FlightDelay(Decorator, object):
+    def get(self, **params):
+        '''
+        Forecast the chances for a flight to be delayed
+
+        .. code-block:: python
+
+        amadeus.travel.predictions.flight_delay.get(originLocationCode='BRU',
+                                                           destinationLocationCode='FRA',
+                                                           departureDate='2020-01-14',
+                                                           departureTime='11:05:00',
+                                                           arrivalDate='2020-01-14',
+                                                           arrivalTime='12:10:00',
+                                                           aircraftCode='32A',
+                                                           carrierCode='LH',
+                                                           flightNumber='1009',
+                                                           duration='PT1H05M')
+
+        :param originLocationCode: the City/Airport IATA code from which
+            the flight will depart. ``"NYC"``, for example for New York
+
+        :param destinationLocationCode: the City/Airport IATA code to which
+            the flight is going. ``"MAD"``, for example for Madrid
+
+        :param departureDate: the date on which the traveler departs
+            from the origin, in `YYYY-MM-DD` format
+
+        :param departureTime: local time on which to fly out,
+            in `HH:MM:SS` format
+
+        :param arrivalDate: the date on which the traveler arrives
+            to the destination, in `YYYY-MM-DD` format
+
+        :param arrivalTime: local time on which the traveler arrives
+            to the destination, in `HH:MM:SS` format
+
+        :param aircraftCode: IATA aircraft code
+
+        :param carrierCode: airline / carrier code
+
+        :param flightNumber: flight number as assigned by the carrier
+
+        :param duration: flight duration,
+            in `PnYnMnDTnHnMnS` format e.g. PT2H10M
+
+        :rtype: amadeus.Response
+        :raises amadeus.ResponseError: if the request could not be completed
+        '''
+        return self.client.get('/v1/travel/predictions/flight-delay', **params)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -74,6 +74,9 @@ Travel/Predictions
 .. autoclass:: amadeus.travel.predictions.TripPurpose
   :members: get
 
+.. autoclass:: amadeus.travel.predictions.FlightDelay
+  :members: get
+
 ReferenceData/Locations
 =======================
 

--- a/specs/namespaces/namespaces_spec.py
+++ b/specs/namespaces/namespaces_spec.py
@@ -37,6 +37,7 @@ with description('Namespaces') as self:
 
         expect(client.travel.predictions).not_to(be_none)
         expect(client.travel.predictions.trip_purpose).not_to(be_none)
+        expect(client.travel.predictions.flight_delay).not_to(be_none)
 
         expect(client.shopping).not_to(be_none)
         expect(client.shopping.flight_dates).not_to(be_none)
@@ -74,6 +75,7 @@ with description('Namespaces') as self:
             be_none)
 
         expect(client.travel.predictions.trip_purpose.get).not_to(be_none)
+        expect(client.travel.predictions.flight_delay.get).not_to(be_none)
 
         expect(client.shopping.flight_dates.get).not_to(be_none)
         expect(client.shopping.flight_destinations.get).not_to(be_none)
@@ -169,6 +171,12 @@ with description('Namespaces') as self:
             self.client.travel.predictions.trip_purpose.get(a='b')
             expect(self.client.get).to(have_been_called_with(
                 '/v1/travel/predictions/trip-purpose', a='b'
+            ))
+
+        with it('.travel.predictions.flight_delay.get'):
+            self.client.travel.predictions.flight_delay.get(a='b')
+            expect(self.client.get).to(have_been_called_with(
+                '/v1/travel/predictions/flight-delay', a='b'
             ))
 
         with it('.shopping.flight_dates.get'):


### PR DESCRIPTION
Fixes #49 

## Changes for this pull request

- Adds Python support for [Flight Delay Prediction API](https://developers.amadeus.com/self-service/category/air/api-doc/flight-delay-prediction).

- The class `FlightDelay()` in the file `amadeus/travel/predictions/_flight_delay.py` contains the method for calling the API programmatically.

- The API can now be called from any application uses the SDK as:
`amadeus.travel.predictions.flight_delay.get(originLocationCode='BRU',
                                                           destinationLocationCode='FRA',
                                                           departureDate='2020-01-14',
                                                           departureTime='11:05:00',
                                                           arrivalDate='2020-01-14',
                                                           arrivalTime='12:10:00',
                                                           aircraftCode='32A',
                                                           carrierCode='LH',
                                                           flightNumber='1009',
                                                           duration='PT1H05M')`.

- Updates docs at `README.str` and `_flight_delay.py`.

- Updates tests at `namespaces_spec.py`.
