### PR TITLE
Support for Airport on Time

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -272,6 +272,9 @@ List of supported endpoints
     # Flight Delay Prediction
     amadeus.travel.predictions.flight_delay.get(originLocationCode='BRU', destinationLocationCode='FRA', departureDate='2020-01-14', departureTime='11:05:00', arrivalDate='2020-01-14', arrivalTime='12:10:00', aircraftCode='32A', carrierCode='LH', flightNumber='1009', duration='PT1H05M')
 
+    # Airport On-Time Performance
+    amadeus.airport.predictions.on_time.get(airportCode='JFK', date='2020-03-01')
+
 Development & Contributing
 --------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -270,7 +270,8 @@ List of supported endpoints
     amadeus.travel.predictions.trip_purpose.get(originLocationCode='ATH', destinationLocationCode='MAD', departureDate='2020-08-01', returnDate='2020-08-12', searchDate='2020-06-11')
 
     # Flight Delay Prediction
-    amadeus.travel.predictions.flight_delay.get(originLocationCode='BRU', destinationLocationCode='FRA', departureDate='2020-01-14', departureTime='11:05:00', arrivalDate='2020-01-14', arrivalTime='12:10:00', aircraftCode='32A', carrierCode='LH', flightNumber='1009', duration='PT1H05M')
+    amadeus.travel.predictions.flight_delay.get(originLocationCode='BRU', destinationLocationCode='FRA', departureDate='2020-01-14', \
+    departureTime='11:05:00', arrivalDate='2020-01-14', arrivalTime='12:10:00', aircraftCode='32A', carrierCode='LH', flightNumber='1009', duration='PT1H05M')
 
     # Airport On-Time Performance
     amadeus.airport.predictions.on_time.get(airportCode='JFK', date='2020-03-01')

--- a/amadeus/airport/__init__.py
+++ b/amadeus/airport/__init__.py
@@ -1,0 +1,3 @@
+from ._predictions import AirportOnTime
+
+__all__ = ['AirportOnTime']

--- a/amadeus/airport/_predictions.py
+++ b/amadeus/airport/_predictions.py
@@ -1,0 +1,8 @@
+from amadeus.client.decorator import Decorator
+from .predictions import AirportOnTime
+
+
+class Predictions(Decorator, object):
+    def __init__(self, client):
+        Decorator.__init__(self, client)
+        self.on_time = AirportOnTime(client)

--- a/amadeus/airport/predictions/__init__.py
+++ b/amadeus/airport/predictions/__init__.py
@@ -1,0 +1,3 @@
+from ._on_time import AirportOnTime
+
+__all__ = ['AirportOnTime']

--- a/amadeus/airport/predictions/_on_time.py
+++ b/amadeus/airport/predictions/_on_time.py
@@ -1,0 +1,24 @@
+from amadeus.client.decorator import Decorator
+
+
+class AirportOnTime(Decorator, object):
+    def get(self, **params):
+        '''
+        Predicts traveler purpose, Business or Leisure,
+        with the probability in the context of search & shopping
+
+        .. code-block:: python
+
+            amadeus.airport.predictions.on_time.get(
+                            airportCode='JFK',
+                            date='2020-03-01')
+
+        :param airportCode: the City/Airport IATA code from which
+            the flight will depart. ``"NYC"``, for example for New York
+
+        :param date: the date on which to fly out, in `YYYY-MM-DD` format
+
+        :rtype: amadeus.Response
+        :raises amadeus.ResponseError: if the request could not be completed
+        '''
+        return self.client.get('/v1/airport/predictions/on-time', **params)

--- a/amadeus/airport/predictions/_on_time.py
+++ b/amadeus/airport/predictions/_on_time.py
@@ -4,8 +4,7 @@ from amadeus.client.decorator import Decorator
 class AirportOnTime(Decorator, object):
     def get(self, **params):
         '''
-        Predicts traveler purpose, Business or Leisure,
-        with the probability in the context of search & shopping
+        Returns a percentage of on-time flight departures
 
         .. code-block:: python
 

--- a/amadeus/namespaces/_airport.py
+++ b/amadeus/namespaces/_airport.py
@@ -1,0 +1,8 @@
+from amadeus.client.decorator import Decorator
+from amadeus.airport._predictions import Predictions
+
+
+class Airport(Decorator, object):
+    def __init__(self, client):
+        Decorator.__init__(self, client)
+        self.predictions = Predictions(client)

--- a/amadeus/namespaces/core.py
+++ b/amadeus/namespaces/core.py
@@ -2,6 +2,7 @@ from amadeus.namespaces._reference_data import ReferenceData
 from amadeus.namespaces._travel import Travel
 from amadeus.namespaces._shopping import Shopping
 from amadeus.namespaces._e_reputation import EReputation
+from amadeus.namespaces._airport import Airport
 
 
 class Core(object):
@@ -10,3 +11,4 @@ class Core(object):
         self.travel = Travel(self)
         self.shopping = Shopping(self)
         self.e_reputation = EReputation(self)
+        self.airport = Airport(self)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -102,3 +102,9 @@ Helper/Location
 ==================
 
 .. autoclass:: amadeus.Location
+
+Airport/Predictions
+================
+
+.. autoclass:: amadeus.airport.predictions.AirportOnTime
+  :members: get

--- a/specs/namespaces/namespaces_spec.py
+++ b/specs/namespaces/namespaces_spec.py
@@ -50,6 +50,7 @@ with description('Namespaces') as self:
 
         expect(client.e_reputation.hotel_sentiments).not_to(be_none)
 
+        expect(client.airport).not_to(be_none)
         expect(client.airport.predictions).not_to(be_none)
         expect(client.airport.predictions.on_time).not_to(be_none)
 

--- a/specs/namespaces/namespaces_spec.py
+++ b/specs/namespaces/namespaces_spec.py
@@ -50,6 +50,9 @@ with description('Namespaces') as self:
 
         expect(client.e_reputation.hotel_sentiments).not_to(be_none)
 
+        expect(client.airport.predictions).not_to(be_none)
+        expect(client.airport.predictions.on_time).not_to(be_none)
+
     with it('should define all expected .get methods'):
         client = self.client
         expect(client.reference_data.urls.checkin_links.get).not_to(be_none)
@@ -86,6 +89,8 @@ with description('Namespaces') as self:
         expect(client.shopping.hotel_offer('123').get).not_to(be_none)
 
         expect(client.e_reputation.hotel_sentiments.get).not_to(be_none)
+
+        expect(client.airport.predictions.on_time.get).not_to(be_none)
 
     with context('testing all calls to the client'):
         with before.each:
@@ -219,4 +224,10 @@ with description('Namespaces') as self:
             self.client.e_reputation.hotel_sentiments.get(hotelIds='XKPARC12')
             expect(self.client.get).to(have_been_called_with(
                 '/v2/e-reputation/hotel-sentiments', hotelIds='XKPARC12'
+            ))
+
+        with it('.airport.predictions.on_time.get'):
+            self.client.airport.predictions.on_time.get(a='b')
+            expect(self.client.get).to(have_been_called_with(
+                '/v1/airport/predictions/on-time', a='b'
             ))


### PR DESCRIPTION
Fixes #47 

## Changes for this pull request

- Adds Python support for [Airport On-Time Performance](https://developers.amadeus.com/self-service/category/air/api-doc/airport-on-time-performance).

- Creates the python package `airport`.

- The class `AirportOnTime()` in the file `amadeus/airport/predictions/_on_time.py` contains the method for calling the API programmatically.

- The API can now be called from any application uses the SDK as:
`amadeus.airport.predictions.on_time.get(airportCode='JFK', date='2020-03-01')`.

- Updates docs at `README.str` and `_on_time.py`.

- Updates tests at `namespaces_spec.py`.
