### PR TITLE
Support for AI Generated Photos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -272,6 +272,9 @@ List of supported endpoints
     # Flight Delay Prediction
     amadeus.travel.predictions.flight_delay.get(originLocationCode='BRU', destinationLocationCode='FRA', departureDate='2020-01-14', departureTime='11:05:00', arrivalDate='2020-01-14', arrivalTime='12:10:00', aircraftCode='32A', carrierCode='LH', flightNumber='1009', duration='PT1H05M')
 
+    # AI Generated Photos
+    amadeus.media.files.generated_photos.get(category='MOUNTAIN')
+
 Development & Contributing
 --------------------------
 

--- a/amadeus/media/__init__.py
+++ b/amadeus/media/__init__.py
@@ -1,0 +1,3 @@
+from ._files import GeneratedPhotos
+
+__all__ = ['GeneratedPhotos']

--- a/amadeus/media/_files.py
+++ b/amadeus/media/_files.py
@@ -1,0 +1,8 @@
+from amadeus.client.decorator import Decorator
+from .files import GeneratedPhotos
+
+
+class Files(Decorator, object):
+    def __init__(self, client):
+        Decorator.__init__(self, client)
+        self.generated_photos = GeneratedPhotos(client)

--- a/amadeus/media/files/__init__.py
+++ b/amadeus/media/files/__init__.py
@@ -1,0 +1,4 @@
+from ._generated_photos import GeneratedPhotos
+
+
+__all__ = ['GeneratedPhotos']

--- a/amadeus/media/files/_generated_photos.py
+++ b/amadeus/media/files/_generated_photos.py
@@ -1,0 +1,19 @@
+from amadeus.client.decorator import Decorator
+
+
+class GeneratedPhotos(Decorator, object):
+    def get(self, **params):
+        '''
+        Returns a link with a rendered image of a landscape
+
+        .. code-block:: python
+
+        amadeus.media.files.generated_photos.get(category='MOUNTAIN')
+
+        :param category: the type of landscape to be generated,
+            ``"MOUNTAIN"`` or ``"BEACH"``
+
+        :rtype: amadeus.Response
+        :raises amadeus.ResponseError: if the request could not be completed
+        '''
+        return self.client.get('/v2/media/files/generated-photos', **params)

--- a/amadeus/namespaces/_media.py
+++ b/amadeus/namespaces/_media.py
@@ -1,0 +1,8 @@
+from amadeus.client.decorator import Decorator
+from amadeus.media._files import Files
+
+
+class Media(Decorator, object):
+    def __init__(self, client):
+        Decorator.__init__(self, client)
+        self.files = Files(client)

--- a/amadeus/namespaces/core.py
+++ b/amadeus/namespaces/core.py
@@ -2,6 +2,7 @@ from amadeus.namespaces._reference_data import ReferenceData
 from amadeus.namespaces._travel import Travel
 from amadeus.namespaces._shopping import Shopping
 from amadeus.namespaces._e_reputation import EReputation
+from amadeus.namespaces._media import Media
 
 
 class Core(object):
@@ -10,3 +11,4 @@ class Core(object):
         self.travel = Travel(self)
         self.shopping = Shopping(self)
         self.e_reputation = EReputation(self)
+        self.media = Media(self)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -102,3 +102,9 @@ Helper/Location
 ==================
 
 .. autoclass:: amadeus.Location
+
+Media/Files
+================
+
+.. autoclass:: amadeus.media.files.GeneratedPhotos
+  :members: get

--- a/specs/namespaces/namespaces_spec.py
+++ b/specs/namespaces/namespaces_spec.py
@@ -50,6 +50,10 @@ with description('Namespaces') as self:
 
         expect(client.e_reputation.hotel_sentiments).not_to(be_none)
 
+        expect(client.media).not_to(be_none)
+        expect(client.media.files).not_to(be_none)
+        expect(client.media.files.generated_photos).not_to(be_none)
+
     with it('should define all expected .get methods'):
         client = self.client
         expect(client.reference_data.urls.checkin_links.get).not_to(be_none)
@@ -86,6 +90,8 @@ with description('Namespaces') as self:
         expect(client.shopping.hotel_offer('123').get).not_to(be_none)
 
         expect(client.e_reputation.hotel_sentiments.get).not_to(be_none)
+
+        expect(client.media.files.generated_photos.get).not_to(be_none)
 
     with context('testing all calls to the client'):
         with before.each:
@@ -219,4 +225,10 @@ with description('Namespaces') as self:
             self.client.e_reputation.hotel_sentiments.get(hotelIds='XKPARC12')
             expect(self.client.get).to(have_been_called_with(
                 '/v2/e-reputation/hotel-sentiments', hotelIds='XKPARC12'
+            ))
+
+        with it('.media.files.generated_photos.get'):
+            self.client.media.files.generated_photos.get(a='b')
+            expect(self.client.get).to(have_been_called_with(
+                '/v2/media/files/generated-photos', a='b'
             ))


### PR DESCRIPTION
Fixes #48 

- Adds Python support for [AI-Generated photos](https://developers.amadeus.com/self-service/category/trip/api-doc/ai-generated-photos).

- Creates the python package `media`.

- The class `GeneratedPhotos()` in the file `amadeus/media/files/_generated_photos.py` contains the method for calling the API programmatically.

- The API can now be called from any application uses the SDK as:
`amadeus.media.files.generated_photos.get(category='MOUNTAIN')`.

- Updates docs at `README.str` and `_generated_photos.py`.

- Updates tests at `namespaces_spec.py`.
