### PR TITLE
update virtualenv version for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ branches:
     - master
     - /^v[0-9]/
 before_install:
-  - pip install virtualenv==15.2.0 
+  - pip install virtualenv==20.0.1
   - pip install tox-travis
 script:
   - tox


### PR DESCRIPTION
Travis fails for Python 2.7 & 3.6.3 when `virtualenv 15.2.0` is installed.
Upgrade to version `20.0.1`