### PR TITLE
Add Support of Hotel Name Autocomplete API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -277,6 +277,9 @@ List of supported endpoints
     # Get list of hotels by a geocode
     amadeus.reference_data.locations.hotels.by_geocode.get(longitude=2.160873,latitude=41.397158)
 
+    # Hotel Name Autocomplete
+    amadeus.reference_data.locations.hotel.get(keyword='PARI', subType=[Hotel.HOTEL_GDS, Hotel.HOTEL_LEISURE])
+
     # Hotel Booking
     # The offerId comes from the hotel_offer above
     amadeus.booking.hotel_bookings.post(offerId, guests, payments)

--- a/amadeus/client/hotel.py
+++ b/amadeus/client/hotel.py
@@ -1,0 +1,22 @@
+#
+class Hotel(object):
+    '''
+    A list of hotel sub types, as used in Hotel Name Autocomplete
+
+    .. code-block:: python
+
+
+        from amadeus import Hotel
+
+        amadeus.reference_data.locations.hotel.get(
+            keyword='PARI',
+            subType=[Hotel.HOTEL_LEISURE, Hotel.HOTEL_GDS]
+        )
+
+    :cvar HOTEL_LEISURE: ``"HOTEL_LEISURE"``
+    :cvar HOTEL_GDS: ``"HOTEL_GDS"``
+    '''
+    # Hotel Leisure
+    HOTEL_LEISURE = 'HOTEL_LEISURE'
+    # Hotel GDS
+    HOTEL_GDS = 'HOTEL_GDS'

--- a/amadeus/client/request.py
+++ b/amadeus/client/request.py
@@ -138,7 +138,7 @@ class Request(object):
 
     # Helper method to prepare the parameter encoding
     def _urlencode(self, d):
-        return urlencode(self._flatten_keys(d, '', {}))
+        return urlencode(self._flatten_keys(d, '', {}), doseq=True)
 
     # Flattens the hash keys, so page: { offset: 1 } becomes page[offet] = 1
     def _flatten_keys(self, d, key, out):

--- a/amadeus/reference_data/_locations.py
+++ b/amadeus/reference_data/_locations.py
@@ -3,6 +3,7 @@ from amadeus.reference_data.locations._airports import Airports
 from amadeus.reference_data.locations._points_of_interest import PointsOfInterest
 from amadeus.reference_data.locations._point_of_interest import PointOfInterest
 from amadeus.reference_data.locations._hotels import Hotels
+from amadeus.reference_data.locations._hotel import Hotel
 
 
 class Locations(Decorator, object):
@@ -11,6 +12,7 @@ class Locations(Decorator, object):
         self.airports = Airports(client)
         self.points_of_interest = PointsOfInterest(client)
         self.hotels = Hotels(client)
+        self.hotel = Hotel(client)
 
     def point_of_interest(self, poi_id):
         return PointOfInterest(self.client, poi_id)

--- a/amadeus/reference_data/locations/__init__.py
+++ b/amadeus/reference_data/locations/__init__.py
@@ -1,3 +1,5 @@
 from ._airports import Airports
 from ._points_of_interest import PointsOfInterest
-__all__ = ['Airports', 'PointsOfInterest']
+from ._hotel import Hotel
+
+__all__ = ['Airports', 'PointsOfInterest', 'Hotel']

--- a/amadeus/reference_data/locations/_hotel.py
+++ b/amadeus/reference_data/locations/_hotel.py
@@ -1,0 +1,26 @@
+from amadeus.client.decorator import Decorator
+
+
+class Hotel(Decorator, object):
+    def get(self, **params):
+        '''
+        Returns a list of hotels matching a given keyword.
+
+        .. code-block:: python
+
+
+            amadeus.reference_data.locations.hotel.get(
+                keyword='PARI',
+                subType=[Hotel.HOTEL_LEISURE, Hotel.HOTEL_GDS]
+            )
+
+        :param keyword: location query keyword.
+            For example: ``PARI``
+        :param subType: category of search.
+            For example: ``[Hotel.HOTEL_LEISURE, Hotel.HOTEL_GDS]``
+
+        :rtype: amadeus.Response
+        :raises amadeus.ResponseError: if the request could not be completed
+        '''
+        return self.client.get(
+            '/v1/reference-data/locations/hotel', **params)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -179,6 +179,12 @@ ReferenceData/Locations/Hotels
 .. autoclass:: amadeus.reference_data.hotels.ByGeocode
   :members: get
 
+ReferenceData/Locations/Hotel
+=======================
+
+.. autoclass:: amadeus.reference_data.locations.Hotel
+  :members: get
+
 Helper/Location
 ==================
 

--- a/specs/namespaces/namespaces_spec.py
+++ b/specs/namespaces/namespaces_spec.py
@@ -28,6 +28,7 @@ with description('Namespaces') as self:
         expect(client.reference_data.locations.hotels.by_hotels).not_to(be_none)
         expect(client.reference_data.locations.hotels.by_city).not_to(be_none)
         expect(client.reference_data.locations.hotels.by_geocode).not_to(be_none)
+        expect(client.reference_data.locations.hotel).not_to(be_none)
         expect(client.travel).not_to(be_none)
         expect(client.travel.analytics).not_to(be_none)
         expect(client.travel.analytics.air_traffic.traveled).not_to(be_none)
@@ -114,6 +115,7 @@ with description('Namespaces') as self:
             client.reference_data.locations.hotels.by_hotels.get).not_to(be_none)
         expect(
             client.reference_data.locations.hotels.by_geocode.get).not_to(be_none)
+        expect(client.reference_data.locations.hotel.get).not_to(be_none)
         expect(client.travel.analytics.air_traffic.traveled.get).not_to(be_none)
         expect(client.travel.analytics.air_traffic.booked.get).not_to(be_none)
         expect(
@@ -554,4 +556,10 @@ with description('Namespaces') as self:
                 a='b')
             expect(self.client.get).to(have_been_called_with(
                 '/v1/reference-data/locations/hotels/by-geocode', a='b'
+            ))
+
+        with it('.reference_data.locations.hotel.get'):
+            self.client.reference_data.locations.hotel.get(a='b')
+            expect(self.client.get).to(have_been_called_with(
+                '/v1/reference-data/locations/hotel', a='b'
             ))


### PR DESCRIPTION
Fixes #145

## Changes for this pull request
* [Add Support of Hotel Name Autocomplete API](https://developers.amadeus.com/self-service/category/hotel/api-doc/hotel-name-autocomplete).
* Add constants for [hotel subType](https://developers.amadeus.com/self-service/category/hotel/api-doc/hotel-name-autocomplete/api-reference#:~:text=Available%20values%20%3A%20HOTEL_LEISURE%2C%20HOTEL_GDS).
* Add arg `doSeq=True` for `urlencode` to support [query parameter repetition](https://developers.amadeus.com/self-service/category/hotel/api-doc/hotel-name-autocomplete/api-reference#:~:text=To%20enter%20several%20value%2C%20repeat%20the%20query%20parameter).
* Added relevant tests.
* Added relevant docs.
