### PR TITLE
generate the coverage report at CI time

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,6 @@
 [run]
 source = ./amadeus
 branch = True
+
+[report]
+fail_under = 95

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@ envlist = py34,py35,py36
 [testenv]
 commands =
   flake8 amadeus specs setup.py
-  mamba
+  mamba --enable-coverage
+  coverage report
 
 deps =
   mamba==0.9.3


### PR DESCRIPTION
Fixes #44 

generate the coverage report at CI time + a check to ensure >95% code coverage

@tsolakoua @minjikarin The PR is ready for review, please go ahead.