### PR TITLE
Fix: List Type Query Parameter for Hotel List API

### DIFF
--- a/amadeus/reference_data/locations/hotels/_by_hotels.py
+++ b/amadeus/reference_data/locations/hotels/_by_hotels.py
@@ -18,5 +18,8 @@ class ByHotels(Decorator, object):
         :rtype: amadeus.Response
         :raises amadeus.ResponseError: if the request could not be completed
         '''
+        for key, value in params.items():
+            if isinstance(value, list):
+                params[key] = ','.join(value)
         return self.client.get(
             '/v1/reference-data/locations/hotels/by-hotels', **params)

--- a/specs/namespaces/test_namespaces.py
+++ b/specs/namespaces/test_namespaces.py
@@ -497,9 +497,10 @@ def test_analytics_itinerary_price_metrics_get(client_setup):
 
 
 def test_reference_data_locations_hotels_by_hotels_get(client_setup):
-    client_setup.reference_data.locations.hotels.by_hotels.get(a='b')
+    client_setup.reference_data.locations.hotels.by_hotels.get(a='b',
+                                                               c=['d', 'e'])
     client_setup.get.assert_called_with(
-        '/v1/reference-data/locations/hotels/by-hotels', a='b'
+        '/v1/reference-data/locations/hotels/by-hotels', a='b', c='d,e'
     )
 
 


### PR DESCRIPTION
Fixes #202 

Previous Request URL
```
https://test.api.amadeus.com/v1/reference-data/locations/hotels/by-hotels?hotelIds=EAMIA276&hotelIds=EAMIAMAP
```

Fixed Request URL
```
https://test.api.amadeus.com/v1/reference-data/locations/hotels/by-hotels?hotelIds=EAMIA276%2CEAMIAMAP
```

## Changes for this pull request

1. Update _by_hotels.py: To flatten a list to a comma-separated string. 
2. Update test_namespaces.py: Added param to the test case.